### PR TITLE
added write permissions to scaffold_length_iteration_1 after copying from lengths file

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import argparse
 import sys
 import subprocess
@@ -68,6 +69,7 @@ def main():
 
         try:
             p = subprocess.check_output(cmd, shell=True)
+            os.chmod(args.output + "/scaffold_length_iteration_1", stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH)
         except subprocess.CalledProcessError as err:
             print >> sys.stderr, str(err.output)
             sys.exit(1)


### PR DESCRIPTION
This pull request resolves #73.

When the lengths file provided with `-l some/length/file` has read-only permissions, those permissions are retained when it is copied to `args.output + "/scaffold_length_iteration_1"`. After copying, this sets the permissions to mode 664 using os.chmod. To use the mode constants in the stat module, this change also imports the stat module.

Of course, there are other ways to fix the issue. One alternative is to include a statement in the README and/or argparse help that the lengths file must have write permissions. If you accept my pull request, additional optional improvements might be checking that the chmod operation was successful or performing an initial check that input files and directories have sufficient permissions. Though, that would arguably be overkill as Python already provides such useful error messages.